### PR TITLE
Wiredep needs main: attribute to correcly inject

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "author": "Vaclav Klecanda",
   "name": "angular-tus-io",
+  "main": "./basic.js",
   "description": "TUS.io client using AngularJS only",
   "version": "1.0.0",
   "homepage": "https://github.com/vencax/angular-tus-io",


### PR DESCRIPTION
If this attribute is missing, wiredep won't inject this project automatically into dependencies (e.g. when working with angular-fullstack)
